### PR TITLE
Add missing "and" to colophon

### DIFF
--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -25,6 +25,7 @@
 			for<br/>
 			<b class="name">Project Gutenberg</b> (<a href="https://www.gutenberg.org/ebooks/41119">A Russian Proprietor</a>, <a href="https://www.gutenberg.org/ebooks/38025">The Complete Works of Count Tolstóy, Volume <span epub:type="z3998:roman">XII</span></a>, <a href="https://www.gutenberg.org/ebooks/51708">Tolstoi for the Young</a>, <a href="https://www.gutenberg.org/ebooks/689">The Kreutzer Sonata and Other Stories</a>, <a href="https://www.gutenberg.org/ebooks/56797">The Invaders and Other Stories</a>, <a href="https://www.gutenberg.org/ebooks/243">The Forged Coupon and Other Stories</a>, <a href="https://www.gutenberg.org/ebooks/986">Master and Man</a>, <a href="https://www.gutenberg.org/ebooks/985">Father Sergius</a> and <a href="https://www.gutenberg.org/ebooks/51018">Three Days in the Village and Other Sketches</a>),<br/>
 			<b class="name">Wikisource</b> (<a href="https://en.wikisource.org/wiki/Family_Happiness">Family Happiness</a>, <a href="https://en.wikisource.org/wiki/Twenty-three_Tales">Twenty-Three Tales</a>, <a href="https://en.wikisource.org/wiki/Diary_of_a_Lunatic">Diary of a Lunatic</a> and <a href="https://en.wikisource.org/wiki/The_Devil">The Devil</a>),<br/>
+			and<br/>
 			<b class="name">Alex Bell</b> and <b class="name">The Tolstoy Library OnLine</b><br/>
 			for the<br/>
 			<b class="name">Patricia Clark Memorial Library</b> (<a href="https://www.mobileread.com/forums/showthread.php?t=279993">The Kreutzer Sonata</a>),<br/>


### PR DESCRIPTION
The colophon is missing an "and" so the sentence is currently not quite grammatical